### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ futures = "0.3"
 tokio = { version = "1.22", features = ["net", "rt", "time"] }
 failure = "0.1"
 byteorder = "1.2"
-lazy_static = "1.0"
 slog = "2.3.2"
 async-trait = "0.1.58"
 pin-project = "1.0.12"
+once_cell = "1.17.0"
 #slog = { version = "2.3.2", features = ['max_level_trace'] }
 
 [dev-dependencies]

--- a/src/types/acl.rs
+++ b/src/types/acl.rs
@@ -3,7 +3,7 @@ use std::ops;
 
 use std::string::ToString;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 /// Describes the ability of a user to perform a certain action.
 ///
@@ -189,11 +189,11 @@ impl Acl {
     }
 }
 
-lazy_static! {
-    static ref ACL_CREATOR_ALL: [Acl; 1] = [Acl::new(Permission::ALL, "auth", "")];
-    static ref ACL_OPEN_UNSAFE: [Acl; 1] = [Acl::new(Permission::ALL, "world", "anyone")];
-    static ref ACL_READ_UNSAFE: [Acl; 1] = [Acl::new(Permission::READ, "world", "anyone")];
-}
+static ACL_CREATOR_ALL: Lazy<[Acl; 1]> = Lazy::new(|| [Acl::new(Permission::ALL, "auth", "")]);
+static ACL_OPEN_UNSAFE: Lazy<[Acl; 1]> =
+    Lazy::new(|| [Acl::new(Permission::ALL, "world", "anyone")]);
+static ACL_READ_UNSAFE: Lazy<[Acl; 1]> =
+    Lazy::new(|| [Acl::new(Permission::READ, "world", "anyone")]);
 
 impl fmt::Display for Acl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
This is a pretty tiny change, but we get rid of one fn-style macro and once_cell is already in our dependency tree. once_cell is also on track for std inclusion, which should let us eliminate that dependency too (https://github.com/rust-lang/rust/issues/74465).