### PR TITLE
Convert from failure to snafu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - main
-      - staging
-      - trying
-      - "renovate/**"
     tags:
       - "*"
   pull_request:
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         rust: [stable, beta, nightly]
-        zookeeper: [3.8.1, 3.7.1, 3.6.4, 3.5.10]
+        zookeeper: [3.9.2, 3.8.4, 3.7.2, 3.6.4, 3.5.10]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: rustup default ${{ matrix.rust }}
-      - run: wget -O zookeeper.tar.gz https://dlcdn.apache.org/zookeeper/zookeeper-${{ matrix.zookeeper }}/apache-zookeeper-${{ matrix.zookeeper }}-bin.tar.gz
+      - run: wget -O zookeeper.tar.gz https://archive.apache.org/zookeeper/zookeeper-${{ matrix.zookeeper }}/apache-zookeeper-${{ matrix.zookeeper }}-bin.tar.gz
       - run: mkdir zookeeper
       - run: tar -zxvf zookeeper.tar.gz -C zookeeper --strip-components 1
       - run: ./scripts/ci-start-zookeeper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - [BREAKING] Migrated errors from Failure to SNAFU ([#39]).
+- Updated ZooKeeper versions we test against (now 3.9.2, 3.8.4, 3.7.2, 3.6.4, 3.5.10) ([#39]).
 
 [#39]: https://github.com/stackabletech/tokio-zookeeper/pull/39
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- [BREAKING] Migrated errors from Failure to SNAFU ([#39]).
+
+[#39]: https://github.com/stackabletech/tokio-zookeeper/pull/39
+
 ## [0.2.1] - 2023-02-13
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ maintenance = { status = "experimental" }
 [dependencies]
 futures = "0.3"
 tokio = { version = "1.22", features = ["net", "rt", "time"] }
-failure = "0.1"
 byteorder = "1.2"
 slog = "2.3.2"
 async-trait = "0.1.58"
 pin-project = "1.0.12"
 once_cell = "1.17.0"
+snafu = "0.8.2"
 #slog = { version = "2.3.2", features = ['max_level_trace'] }
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,39 +1,35 @@
-use failure::Fail;
+use snafu::Snafu;
 
 /// Errors that may cause a delete request to fail.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Snafu)]
+#[snafu(module)]
 pub enum Delete {
     /// No node exists with the given `path`.
-    #[fail(display = "target node does not exist")]
+    #[snafu(display("target node does not exist"))]
     NoNode,
 
     /// The target node has a different version than was specified by the call to delete.
-    #[fail(
-        display = "target node has different version than expected ({})",
-        expected
-    )]
+    #[snafu(display("target node has different version than expected ({expected})"))]
     BadVersion {
         /// The expected node version.
         expected: i32,
     },
 
     /// The target node has child nodes, and therefore cannot be deleted.
-    #[fail(display = "target node has children, and cannot be deleted")]
+    #[snafu(display("target node has children, and cannot be deleted"))]
     NotEmpty,
 }
 
 /// Errors that may cause a `set_data` request to fail.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Snafu)]
+#[snafu(module)]
 pub enum SetData {
     /// No node exists with the given `path`.
-    #[fail(display = "target node does not exist")]
+    #[snafu(display("target node does not exist"))]
     NoNode,
 
     /// The target node has a different version than was specified by the call to `set_data`.
-    #[fail(
-        display = "target node has different version than expected ({})",
-        expected
-    )]
+    #[snafu(display("target node has different version than expected ({expected})"))]
     BadVersion {
         /// The expected node version.
         expected: i32,
@@ -41,77 +37,75 @@ pub enum SetData {
 
     /// The target node's permission does not accept data modification or requires different
     /// authentication to be altered.
-    #[fail(display = "insuficient authentication")]
+    #[snafu(display("insuficient authentication"))]
     NoAuth,
 }
 
 /// Errors that may cause a create request to fail.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Snafu)]
+#[snafu(module)]
 pub enum Create {
     /// A node with the given `path` already exists.
-    #[fail(display = "target node already exists")]
+    #[snafu(display("target node already exists"))]
     NodeExists,
 
     /// The parent node of the given `path` does not exist.
-    #[fail(display = "parent node of target does not exist")]
+    #[snafu(display("parent node of target does not exist"))]
     NoNode,
 
     /// The parent node of the given `path` is ephemeral, and cannot have children.
-    #[fail(display = "parent node is ephemeral, and cannot have children")]
+    #[snafu(display("parent node is ephemeral, and cannot have children"))]
     NoChildrenForEphemerals,
 
     /// The given ACL is invalid.
-    #[fail(display = "the given ACL is invalid")]
+    #[snafu(display("the given ACL is invalid"))]
     InvalidAcl,
 }
 
 /// Errors that may cause a `get_acl` request to fail.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Snafu)]
+#[snafu(module)]
 pub enum GetAcl {
     /// No node exists with the given `path`.
-    #[fail(display = "target node does not exist")]
+    #[snafu(display("target node does not exist"))]
     NoNode,
 }
 
 /// Errors that may cause a `set_acl` request to fail.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Snafu)]
+#[snafu(module)]
 pub enum SetAcl {
     /// No node exists with the given `path`.
-    #[fail(display = "target node does not exist")]
+    #[snafu(display("target node does not exist"))]
     NoNode,
 
     /// The target node has a different version than was specified by the call to `set_acl`.
-    #[fail(
-        display = "target node has different version than expected ({})",
-        expected
-    )]
+    #[snafu(display("target node has different version than expected ({expected})"))]
     BadVersion {
         /// The expected node version.
         expected: i32,
     },
 
     /// The given ACL is invalid.
-    #[fail(display = "the given ACL is invalid")]
+    #[snafu(display("the given ACL is invalid"))]
     InvalidAcl,
 
     /// The target node's permission does not accept acl modification or requires different
     /// authentication to be altered.
-    #[fail(display = "insufficient authentication")]
+    #[snafu(display("insufficient authentication"))]
     NoAuth,
 }
 
 /// Errors that may cause a `check` request to fail.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Snafu)]
+#[snafu(module)]
 pub enum Check {
     /// No node exists with the given `path`.
-    #[fail(display = "target node does not exist")]
+    #[snafu(display("target node does not exist"))]
     NoNode,
 
     /// The target node has a different version than was specified by the call to `check`.
-    #[fail(
-        display = "target node has different version than expected ({})",
-        expected
-    )]
+    #[snafu(display("target node has different version than expected ({expected})"))]
     BadVersion {
         /// The expected node version.
         expected: i32,
@@ -119,55 +113,43 @@ pub enum Check {
 }
 
 /// The result of a failed `multi` request.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Snafu)]
 pub enum Multi {
     /// A failed `delete` request.
-    #[fail(display = "delete failed: {}", 0)]
-    Delete(Delete),
+    #[snafu(display("delete failed"), context(false))]
+    Delete {
+        /// The source error.
+        source: Delete,
+    },
 
     /// A failed `set_data` request.
-    #[fail(display = "set_data failed: {}", 0)]
-    SetData(SetData),
+    #[snafu(display("set_data failed"), context(false))]
+    SetData {
+        /// The source error.
+        source: SetData,
+    },
 
     /// A failed `create` request.
-    #[fail(display = "create failed: {}", 0)]
-    Create(Create),
+    #[snafu(display("create failed"), context(false))]
+    Create {
+        /// The source error.
+        source: Create,
+    },
 
     /// A failed `check` request.
-    #[fail(display = "check failed")]
-    Check(Check),
+    #[snafu(display("check failed"), context(false))]
+    Check {
+        /// The source error.
+        source: Check,
+    },
 
     /// The request would have succeeded, but a later request in the `multi`
     /// batch failed and caused this request to get rolled back.
-    #[fail(display = "request rolled back due to later failed request")]
+    #[snafu(display("request rolled back due to later failed request"))]
     RolledBack,
 
     /// The request was skipped because an earlier request in the `multi` batch
     /// failed. It is unknown whether this request would have succeeded.
-    #[fail(display = "request failed due to earlier failed request")]
+    #[snafu(display("request failed due to earlier failed request"))]
     Skipped,
-}
-
-impl From<Delete> for Multi {
-    fn from(err: Delete) -> Self {
-        Multi::Delete(err)
-    }
-}
-
-impl From<SetData> for Multi {
-    fn from(err: SetData) -> Self {
-        Multi::SetData(err)
-    }
-}
-
-impl From<Create> for Multi {
-    fn from(err: Create) -> Self {
-        Multi::Create(err)
-    }
-}
-
-impl From<Check> for Multi {
-    fn from(err: Check) -> Self {
-        Multi::Check(err)
-    }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::error::Error;
 use std::net::SocketAddr;
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -18,7 +19,7 @@ pub(crate) use self::watch::Watch;
 #[async_trait]
 pub trait ZooKeeperTransport: AsyncRead + AsyncWrite + Sized + Send + 'static {
     type Addr: Send + Clone;
-    type ConnectError: Into<failure::Error> + 'static;
+    type ConnectError: Error + 'static;
     async fn connect(addr: Self::Addr) -> Result<Self, Self::ConnectError>;
 }
 

--- a/src/proto/request.rs
+++ b/src/proto/request.rs
@@ -1,9 +1,9 @@
 use super::Watch;
 use super::ZkError;
+use crate::{Acl, CreateMode};
 use byteorder::{BigEndian, WriteBytesExt};
 use std::borrow::Cow;
 use std::io::{self, Write};
-use crate::{Acl, CreateMode};
 
 #[derive(Debug)]
 pub(crate) enum Request {

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -148,7 +148,7 @@ impl<R: Read> StringReader for R {
 }
 
 impl Response {
-    pub(super) fn parse(opcode: OpCode, reader: &mut &[u8]) -> Result<Self, failure::Error> {
+    pub(super) fn parse(opcode: OpCode, reader: &mut &[u8]) -> io::Result<Self> {
         match opcode {
             OpCode::CreateSession => Ok(Response::Connect {
                 protocol_version: reader.read_i32::<BigEndian>()?,


### PR DESCRIPTION
Fixes #38. This is an initial conversion that tries to change as little as possible (generally: `failure::Error` -> `snafu::Whatever`, `failure::Fail` -> `snafu::{Snafu, Error}`), a future PR should clean up to use more Snafu-native idioms.